### PR TITLE
Use canvas scale util

### DIFF
--- a/app/lib/stores/useCanvasStore.ts
+++ b/app/lib/stores/useCanvasStore.ts
@@ -2,6 +2,7 @@ import { nanoid } from 'nanoid';
 import { create } from 'zustand';
 import { DEFAULT_CANVAS_SIZE } from '../constants/canvas';
 import { CanvasContextType, Element, HistoryAction } from '../types/canvas.types';
+import { scaleElement as scaleElementUtil } from '../utils/canvas-utils';
 import useEditorStore from './useEditorStore';
 
 interface CanvasState extends Omit<CanvasContextType, 'elements' | 'canvasSize'> {
@@ -465,16 +466,9 @@ const useCanvasStore = create<CanvasState>((set, get) => ({
     get().updateElement(id, { isNew: false });
   },
 
-  // Helper to scale an element's position and size
+  // Helper to scale an element
   scaleElement: (element, scaleFactor) => {
-    return {
-      ...element,
-      x: element.x * scaleFactor,
-      y: element.y * scaleFactor,
-      width: element.width * scaleFactor,
-      height: element.height * scaleFactor,
-      fontSize: element.fontSize ? element.fontSize * scaleFactor : undefined
-    };
+    return scaleElementUtil(element, scaleFactor);
   },
 
   // Undo the last action


### PR DESCRIPTION
## Summary
- import `scaleElement` helper into `useCanvasStore`
- delegate element scaling to the shared util

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684196f8bd108320bf47acffcdc15ae3