### PR TITLE
Refactor canvas store page lookup

### DIFF
--- a/app/lib/stores/useCanvasStore.ts
+++ b/app/lib/stores/useCanvasStore.ts
@@ -36,7 +36,14 @@ interface CanvasState extends Omit<CanvasContextType, 'elements' | 'canvasSize'>
 }
 
 // Create the canvas store
-const useCanvasStore = create<CanvasState>((set, get) => ({
+const useCanvasStore = create<CanvasState>((set, get) => {
+  const getCurrentPage = () => {
+    const { currentPageId, pages } = useEditorStore.getState();
+    if (!currentPageId) return null;
+    return pages.find(page => page.id === currentPageId) || null;
+  };
+
+  return {
   // Elements selection state
   selectedElement: null,
   selectedElementIds: [],
@@ -82,12 +89,9 @@ const useCanvasStore = create<CanvasState>((set, get) => ({
   addElement: (elementData) => {
     const editor = useEditorStore.getState();
     const currentPageId = editor.currentPageId;
+    const currentPage = getCurrentPage();
 
-    if (!currentPageId) return;
-
-    const currentPage = editor.pages.find(page => page.id === currentPageId);
-
-    if (!currentPage) return;
+    if (!currentPageId || !currentPage) return;
 
     // Generate a unique ID for the new element
     const newElement: Element = {
@@ -129,12 +133,9 @@ const useCanvasStore = create<CanvasState>((set, get) => ({
   updateElement: (id, updates) => {
     const editor = useEditorStore.getState();
     const currentPageId = editor.currentPageId;
+    const currentPage = getCurrentPage();
 
-    if (!currentPageId) return;
-
-    const currentPage = editor.pages.find(page => page.id === currentPageId);
-
-    if (!currentPage) return;
+    if (!currentPageId || !currentPage) return;
 
     // Find the element to update
     const elementToUpdate = currentPage.elements.find(el => el.id === id);
@@ -187,12 +188,9 @@ const useCanvasStore = create<CanvasState>((set, get) => ({
     const state = get();
     const currentPageId = editor.currentPageId;
     const selectedIds = state.selectedElementIds;
+    const currentPage = getCurrentPage();
 
-    if (!currentPageId || selectedIds.length === 0) return;
-
-    const currentPage = editor.pages.find(page => page.id === currentPageId);
-
-    if (!currentPage) return;
+    if (!currentPageId || !currentPage || selectedIds.length === 0) return;
 
     // Store previous states for history
     const updatedElements = currentPage.elements.map(element => {
@@ -231,12 +229,9 @@ const useCanvasStore = create<CanvasState>((set, get) => ({
   deleteElement: (id) => {
     const editor = useEditorStore.getState();
     const currentPageId = editor.currentPageId;
+    const currentPage = getCurrentPage();
 
-    if (!currentPageId) return;
-
-    const currentPage = editor.pages.find(page => page.id === currentPageId);
-
-    if (!currentPage) return;
+    if (!currentPageId || !currentPage) return;
 
     // Find the element to delete for history
     const elementToDelete = currentPage.elements.find(el => el.id === id);
@@ -301,12 +296,9 @@ const useCanvasStore = create<CanvasState>((set, get) => ({
   selectElement: (id, addToSelection = false) => {
     const editor = useEditorStore.getState();
     const currentPageId = editor.currentPageId;
+    const currentPage = getCurrentPage();
 
-    if (!currentPageId) return;
-
-    const currentPage = editor.pages.find(page => page.id === currentPageId);
-
-    if (!currentPage || !id) {
+    if (!currentPageId || !currentPage || !id) {
       // If id is null, clear selection
       set({
         selectedElement: null,
@@ -410,12 +402,9 @@ const useCanvasStore = create<CanvasState>((set, get) => ({
   changeCanvasSize: (size) => {
     const editor = useEditorStore.getState();
     const currentPageId = editor.currentPageId;
+    const currentPage = getCurrentPage();
 
-    if (!currentPageId) return;
-
-    const currentPage = editor.pages.find(page => page.id === currentPageId);
-
-    if (!currentPage) return;
+    if (!currentPageId || !currentPage) return;
 
     // Store the previous size for history
     const before = { ...currentPage.canvasSize };
@@ -449,12 +438,9 @@ const useCanvasStore = create<CanvasState>((set, get) => ({
   clearNewElementFlag: (id) => {
     const editor = useEditorStore.getState();
     const currentPageId = editor.currentPageId;
+    const currentPage = getCurrentPage();
 
-    if (!currentPageId) return;
-
-    const currentPage = editor.pages.find(page => page.id === currentPageId);
-
-    if (!currentPage) return;
+    if (!currentPageId || !currentPage) return;
 
     // Find the element
     const element = currentPage.elements.find(el => el.id === id);
@@ -715,12 +701,9 @@ const useCanvasStore = create<CanvasState>((set, get) => ({
   duplicateElement: (id: string) => {
     const editor = useEditorStore.getState();
     const currentPageId = editor.currentPageId;
+    const currentPage = getCurrentPage();
 
-    if (!currentPageId) return;
-
-    const currentPage = editor.pages.find(page => page.id === currentPageId);
-
-    if (!currentPage) return;
+    if (!currentPageId || !currentPage) return;
 
     // Find the element to duplicate
     const elementToDuplicate = currentPage.elements.find(el => el.id === id);
@@ -799,10 +782,8 @@ const useCanvasStore = create<CanvasState>((set, get) => ({
   bringElementForward: (elementId) => {
     const editor = useEditorStore.getState();
     const currentPageId = editor.currentPageId;
-    if (!currentPageId) return;
-
-    const currentPage = editor.pages.find(page => page.id === currentPageId);
-    if (!currentPage) return;
+    const currentPage = getCurrentPage();
+    if (!currentPageId || !currentPage) return;
 
     const elements = [...currentPage.elements];
     const index = elements.findIndex(el => el.id === elementId);
@@ -832,10 +813,8 @@ const useCanvasStore = create<CanvasState>((set, get) => ({
   sendElementBackward: (elementId) => {
     const editor = useEditorStore.getState();
     const currentPageId = editor.currentPageId;
-    if (!currentPageId) return;
-
-    const currentPage = editor.pages.find(page => page.id === currentPageId);
-    if (!currentPage) return;
+    const currentPage = getCurrentPage();
+    if (!currentPageId || !currentPage) return;
 
     const elements = [...currentPage.elements];
     const index = elements.findIndex(el => el.id === elementId);
@@ -865,10 +844,8 @@ const useCanvasStore = create<CanvasState>((set, get) => ({
   bringElementToFront: (elementId) => {
     const editor = useEditorStore.getState();
     const currentPageId = editor.currentPageId;
-    if (!currentPageId) return;
-
-    const currentPage = editor.pages.find(page => page.id === currentPageId);
-    if (!currentPage) return;
+    const currentPage = getCurrentPage();
+    if (!currentPageId || !currentPage) return;
 
     const elements = [...currentPage.elements];
     const index = elements.findIndex(el => el.id === elementId);
@@ -898,10 +875,8 @@ const useCanvasStore = create<CanvasState>((set, get) => ({
   sendElementToBack: (elementId) => {
     const editor = useEditorStore.getState();
     const currentPageId = editor.currentPageId;
-    if (!currentPageId) return;
-
-    const currentPage = editor.pages.find(page => page.id === currentPageId);
-    if (!currentPage) return;
+    const currentPage = getCurrentPage();
+    if (!currentPageId || !currentPage) return;
 
     const elements = [...currentPage.elements];
     const index = elements.findIndex(el => el.id === elementId);
@@ -927,7 +902,8 @@ const useCanvasStore = create<CanvasState>((set, get) => ({
       canRedo: false,
     }));
   },
-}));
+  };
+});
 
 // Create a selector to get the current page elements
 export const useCurrentPageElements = () => {


### PR DESCRIPTION
## Summary
- add `getCurrentPage()` helper inside `useCanvasStore`
- use helper in element and canvas update operations

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684196f90058832095701d6c39866584