### PR TITLE
Add undo/redo for element reordering

### DIFF
--- a/app/lib/stores/useCanvasStore.ts
+++ b/app/lib/stores/useCanvasStore.ts
@@ -2,6 +2,7 @@ import { nanoid } from 'nanoid';
 import { create } from 'zustand';
 import { DEFAULT_CANVAS_SIZE } from '../constants/canvas';
 import { CanvasContextType, Element, HistoryAction } from '../types/canvas.types';
+import { reorderByIndex } from '../utils/canvas-utils';
 import useEditorStore from './useEditorStore';
 
 interface CanvasState extends Omit<CanvasContextType, 'elements' | 'canvasSize'> {
@@ -564,6 +565,15 @@ const useCanvasStore = create<CanvasState>((set, get) => ({
         break;
       }
 
+      case 'REORDER_ELEMENT': {
+        const currentPage = editor.pages.find(page => page.id === action.pageId);
+        if (!currentPage) break;
+
+        const reordered = reorderByIndex(currentPage.elements, action.toIndex, action.fromIndex);
+        editor.updatePageElements(action.pageId, reordered);
+        break;
+      }
+
       // Handle other action types as needed
     }
 
@@ -659,6 +669,15 @@ const useCanvasStore = create<CanvasState>((set, get) => ({
 
         // Apply the canvas size change
         editor.updatePageCanvasSize(action.pageId, action.after);
+        break;
+      }
+
+      case 'REORDER_ELEMENT': {
+        const currentPage = editor.pages.find(page => page.id === action.pageId);
+        if (!currentPage) break;
+
+        const reordered = reorderByIndex(currentPage.elements, action.fromIndex, action.toIndex);
+        editor.updatePageElements(action.pageId, reordered);
         break;
       }
 

--- a/app/lib/utils/canvas-utils.ts
+++ b/app/lib/utils/canvas-utils.ts
@@ -134,3 +134,17 @@ export const calculateViewportRect = (
     height: viewportHeight
   };
 };
+
+/**
+ * Reorders an array item by moving it from one index to another.
+ * @param items - The array of items to modify
+ * @param from - The original index of the item
+ * @param to - The target index for the item
+ * @returns A new array with the item moved
+ */
+export const reorderByIndex = <T>(items: T[], from: number, to: number): T[] => {
+  const updated = [...items];
+  const [moved] = updated.splice(from, 1);
+  updated.splice(to, 0, moved);
+  return updated;
+};


### PR DESCRIPTION
## Summary
- add generic `reorderByIndex` utility
- use `reorderByIndex` when undoing and redoing `REORDER_ELEMENT` actions

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684196f82cf88320822ad719f539b722