### PR TITLE
Refactor sidebar popover

### DIFF
--- a/app/(routes)/editor/components/ElementPropertyBar.tsx
+++ b/app/(routes)/editor/components/ElementPropertyBar.tsx
@@ -106,8 +106,8 @@ const ElementPropertyBarComponent: ForwardRefRenderFunction<HTMLDivElement, Elem
   const [isStrikethrough, setIsStrikethrough] = useState(selectedElement?.isStrikethrough || false)
   // Add position state
 
-  const openPopover = useEditorStore((state) => state.openPopover);
-  const isPopoverOpen = useEditorStore((state) => state.popover.isOpen);
+  const openSidebarPanel = useEditorStore((state) => state.openSidebarPanel);
+  const isPanelOpen = useEditorStore((state) => state.sidebarPanel.isOpen);
 
 
   const toolbarRef = useRef<HTMLDivElement>(null)
@@ -239,17 +239,17 @@ const ElementPropertyBarComponent: ForwardRefRenderFunction<HTMLDivElement, Elem
 
   const handleTextColorButtonClick = useCallback((e: React.MouseEvent) => {
     e.stopPropagation();
-    openPopover("text-color");
-  }, [openPopover]);
+    openSidebarPanel("text-color");
+  }, [openSidebarPanel]);
 
   const handleBackgroundColorButtonClick = useCallback((e: React.MouseEvent) => {
     e.stopPropagation();
-    openPopover("background-color");
-  }, [openPopover]);
+    openSidebarPanel("background-color");
+  }, [openSidebarPanel]);
 
   useEffect(() => {
-    console.log('isPopoverOpen changed:', isPopoverOpen);
-  }, [isPopoverOpen]);
+    console.log('isPanelOpen changed:', isPanelOpen);
+  }, [isPanelOpen]);
 
   // Clean up timeout on unmount
   useEffect(() => {

--- a/app/(routes)/editor/components/Sidebar.tsx
+++ b/app/(routes)/editor/components/Sidebar.tsx
@@ -7,7 +7,7 @@ import useCanvasStore, { useCurrentCanvasSize } from "@/lib/stores/useCanvasStor
 import useEditorStore from "@/lib/stores/useEditorStore";
 import { ArrowRight, ChevronRight, Circle, Palette, Search } from "lucide-react";
 import { useCallback } from "react";
-import { SidebarPopover } from "./SidebarPopover";
+import { SidebarPanel } from "./SidebarPanel";
 import { useQuery } from "@tanstack/react-query";
 import { brandsAPI } from "@/lib/api";
 import { Brand } from "@/lib/types/brands";
@@ -612,15 +612,14 @@ const DefaultPopoverContent = ({ activeItemId }: { activeItemId: string }) => (
 );
 
 const EditorSidebar = ({ onTextColorChange, onBackgroundColorChange }: EditorSidebarProps) => {
-    const openPopover = useEditorStore((state) => state.openPopover);
-    const activeItemId = useEditorStore((state) => state.popover.activeItemId);
+    const openSidebarPanel = useEditorStore((state) => state.openSidebarPanel);
+    const activeItemId = useEditorStore((state) => state.sidebarPanel.activeItemId);
     const canvasSize = useCurrentCanvasSize();
     const addElement = useCanvasStore(state => state.addElement);
 
     const handleItemClick = useCallback((itemId: string) => {
-        // Close any open popover
-        openPopover(itemId);
-    }, [openPopover]);
+        openSidebarPanel(itemId);
+    }, [openSidebarPanel]);
 
     // Function to create different shapes
     const handleAddShape = useCallback((shapeType: "rectangle" | "circle" | "line" | "arrow") => {
@@ -651,8 +650,8 @@ const EditorSidebar = ({ onTextColorChange, onBackgroundColorChange }: EditorSid
                 break;
         }
 
-        // Optional: Close the popover after adding a shape
-        // openPopover("");
+        // Optional: Close the panel after adding a shape
+        // openSidebarPanel("");
     }, [addElement, canvasSize.width, canvasSize.height]);
 
     // Render appropriate content based on active item
@@ -678,9 +677,9 @@ const EditorSidebar = ({ onTextColorChange, onBackgroundColorChange }: EditorSid
                 variant="editor"
                 onItemClick={handleItemClick}
             />
-            <SidebarPopover>
+            <SidebarPanel>
                 {renderPopoverContent()}
-            </SidebarPopover>
+            </SidebarPanel>
         </>
     );
 };

--- a/app/(routes)/editor/components/SidebarPanel.tsx
+++ b/app/(routes)/editor/components/SidebarPanel.tsx
@@ -1,8 +1,9 @@
 import React, { useRef, ReactNode } from 'react';
 import * as Popover from "@radix-ui/react-popover";
 import useEditorStore from "@/lib/stores/useEditorStore";
+import { SidebarPanelMode } from "@/lib/types/sidebar";
 
-interface SidebarPopoverProps {
+interface SidebarPanelProps {
   /** Content to render inside the popover */
   children: ReactNode;
   /** Custom width for the popover. Defaults to 450px */
@@ -22,22 +23,22 @@ interface SidebarPopoverProps {
 }
 
 /**
- * Reusable sidebar popover component that handles the floating panel logic.
+ * Reusable sidebar panel component that handles the floating panel logic.
  * 
  * This component abstracts the common popover behavior used in the editor sidebar,
  * providing a consistent layout and positioning system while allowing flexible content.
  * 
  * @example
  * ```tsx
- * <SidebarPopover>
+ * <SidebarPanel>
  *   <div className="p-6">
  *     <h3>My Content</h3>
  *     <p>Custom popover content goes here</p>
  *   </div>
- * </SidebarPopover>
+ * </SidebarPanel>
  * ```
  */
-export const SidebarPopover: React.FC<SidebarPopoverProps> = ({
+export const SidebarPanel: React.FC<SidebarPanelProps> = ({
   children,
   width = 450,
   height = "var(--editor-sidebar-popover-height)",
@@ -48,11 +49,42 @@ export const SidebarPopover: React.FC<SidebarPopoverProps> = ({
   contentPadding = "0.5rem"
 }) => {
   const popoverRef = useRef<HTMLDivElement>(null);
-  const isPopoverOpen = useEditorStore((state) => state.popover.isOpen);
+  const isOpen = useEditorStore((state) => state.sidebarPanel.isOpen);
+  const mode = useEditorStore((state) => state.sidebarPanel.mode);
 
   // Only render the popover content when it should be open
-  if (!isPopoverOpen) {
+  if (!isOpen) {
     return null;
+  }
+
+  const panelContent = (
+    <div
+      className={`
+          border border-neutral-200 shadow-xl rounded-xl bg-white
+          ${scrollable ? 'overflow-y-scroll' : 'overflow-hidden'}
+          ${className}
+        `}
+      style={{
+        width: typeof width === 'number' ? `${width}px` : width,
+        height: height,
+        padding: contentPadding,
+      }}
+    >
+      {children}
+    </div>
+  );
+
+  if (mode === SidebarPanelMode.DEFAULT) {
+    return (
+      <div
+        ref={popoverRef}
+        className="z-sidebar-popover"
+        style={{ paddingLeft: leftOffset, paddingTop: topOffset }}
+        data-editor-interactive="true"
+      >
+        {panelContent}
+      </div>
+    );
   }
 
   return (
@@ -69,22 +101,9 @@ export const SidebarPopover: React.FC<SidebarPopoverProps> = ({
       }}
       data-editor-interactive="true"
     >
-      <div
-        className={`
-          border border-neutral-200 shadow-xl rounded-xl bg-white
-          ${scrollable ? 'overflow-y-scroll' : 'overflow-hidden'}
-          ${className}
-        `}
-        style={{
-          width: typeof width === 'number' ? `${width}px` : width,
-          height: height,
-          padding: contentPadding
-        }}
-      >
-        {children}
-      </div>
+      {panelContent}
     </Popover.Content>
   );
 };
 
-export default SidebarPopover;
+export default SidebarPanel;

--- a/app/(routes)/editor/layout.tsx
+++ b/app/(routes)/editor/layout.tsx
@@ -27,16 +27,16 @@ export default function EditorLayout({
 }
 
 function EditorLayoutContent({ children }: { children: React.ReactNode }) {
-    const isPopoverOpen = useEditorStore((state) => state.popover.isOpen);
-    const closePopover = useEditorStore((state) => state.closePopover);
+    const isPanelOpen = useEditorStore((state) => state.sidebarPanel.isOpen);
+    const closeSidebarPanel = useEditorStore((state) => state.closeSidebarPanel);
     const { handleTextColorChange, handleBackgroundColorChange } = useCanvas();
 
     return (
-        <Popover.Root 
-            open={isPopoverOpen} 
+        <Popover.Root
+            open={isPanelOpen}
             onOpenChange={(open) => {
                 if (!open) {
-                    closePopover();
+                    closeSidebarPanel();
                 }
             }}
         >

--- a/app/lib/stores/useEditorStore.ts
+++ b/app/lib/stores/useEditorStore.ts
@@ -2,22 +2,25 @@ import { projectsAPI } from "@/lib/api";
 import { create } from "zustand";
 import { DEFAULT_CANVAS_SIZE } from "../constants/canvas";
 import { CanvasSize, EditorContextType, Element, Page } from "../types/canvas.types";
+import { SidebarPanelMode } from "../types/sidebar";
 
 // Define the store state interface
 interface EditorState extends Omit<EditorContextType, "currentPage"> {
   designId: string | null;
   captureCanvasScreenshot: () => Promise<string | undefined>;
 
-  // Sidebar popover state
-  popover: {
+  // Sidebar panel state
+  sidebarPanel: {
     isOpen: boolean;
     activeItemId: string | null;
-    content: React.ReactNode | null; // Add the missing content property
+    content: React.ReactNode | null;
+    mode: SidebarPanelMode;
   };
 
-  // Sidebar popover actions
-  openPopover: (itemId: string) => void;
-  closePopover: () => void;
+  // Sidebar panel actions
+  openSidebarPanel: (itemId: string) => void;
+  closeSidebarPanel: () => void;
+  setSidebarPanelMode: (mode: SidebarPanelMode) => void;
 }
 
 // Create the editor store
@@ -42,11 +45,12 @@ const useEditorStore = create<EditorState>((set, get) => ({
   currentPageId: `page-${Date.now()}`,
   currentPageIndex: 0,
 
-  // Sidebar popover state
-  popover: {
+  // Sidebar panel state
+  sidebarPanel: {
     isOpen: false,
     activeItemId: null,
-    content: null
+    content: null,
+    mode: SidebarPanelMode.POPOVER,
   },
 
   // Toggle between edit and view mode
@@ -308,21 +312,32 @@ const useEditorStore = create<EditorState>((set, get) => ({
     });
   },
 
-  // Sidebar popover actions
-  openPopover: (itemId: string) => set({
-    popover: {
-      isOpen: true,
-      activeItemId: itemId,
-      content: undefined
-    }
-  }),
-  closePopover: () => set({
-    popover: {
-      isOpen: false,
-      activeItemId: null,
-      content: undefined
-    }
-  })
+  // Sidebar panel actions
+  openSidebarPanel: (itemId: string) =>
+    set(state => ({
+      sidebarPanel: {
+        ...state.sidebarPanel,
+        isOpen: true,
+        activeItemId: itemId,
+        content: undefined,
+      },
+    })),
+  closeSidebarPanel: () =>
+    set(state => ({
+      sidebarPanel: {
+        ...state.sidebarPanel,
+        isOpen: false,
+        activeItemId: null,
+        content: undefined,
+      },
+    })),
+  setSidebarPanelMode: (mode: SidebarPanelMode) =>
+    set(state => ({
+      sidebarPanel: {
+        ...state.sidebarPanel,
+        mode,
+      },
+    }))
 }));
 
 // Add a currentPage selector

--- a/app/lib/types/sidebar.ts
+++ b/app/lib/types/sidebar.ts
@@ -1,0 +1,4 @@
+export enum SidebarPanelMode {
+  POPOVER = 'POPOVER',
+  DEFAULT = 'DEFAULT'
+}


### PR DESCRIPTION
## Summary
- rename SidebarPopover -> SidebarPanel
- add SidebarPanelMode state and expose in store
- use new panel state in ElementPropertyBar, Sidebar, and editor layout

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841be5e84f48320b6a03f988eafb45e