### PR TITLE
Fix import path in text measurement hook

### DIFF
--- a/app/(routes)/editor/hooks/useTextMeasurement.tsx
+++ b/app/(routes)/editor/hooks/useTextMeasurement.tsx
@@ -1,5 +1,5 @@
 import { useRef, useCallback } from "react";
-import { Element as CanvasElement } from "@lib/types/canvasTypes";
+import { Element as CanvasElement } from "@lib/types/canvas.types";
 
 /**
  * Hook to handle text measurement and auto-height adjustment


### PR DESCRIPTION
## Summary
- update import path for canvas types to `@lib/types/canvas.types`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684324713a748320aa89259fb5c96b91