### PR TITLE
Fix hover clearing after resizing

### DIFF
--- a/app/(routes)/editor/hooks/useCanvasElementInteraction.ts
+++ b/app/(routes)/editor/hooks/useCanvasElementInteraction.ts
@@ -131,12 +131,11 @@ export function useCanvasElementInteraction(elementRef?: React.RefObject<HTMLDiv
   }, []);
 
   const handleMouseLeave = useCallback((onHover?: (id: string | null) => void) => {
-    if (justFinishedResizing.current) {
-      // If we just finished resizing, prevent immediate deselect
-      setIsHovering(false);
-      return;
-    }
+    // Always reset local hover state
     setIsHovering(false);
+
+    // Previously we avoided notifying hover end when just finishing a resize,
+    // but we now always invoke onHover(null) so the highlight clears correctly
     onHover?.(null);
   }, []);
 


### PR DESCRIPTION
## Summary
- ensure handleMouseLeave always notifies hover end

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68432472ff0c832087e5b94f6e982db8