### PR TITLE
Fix drag listeners cleanup on resize

### DIFF
--- a/app/(routes)/editor/components/canvas/controls/ElementControls.tsx
+++ b/app/(routes)/editor/components/canvas/controls/ElementControls.tsx
@@ -275,7 +275,7 @@ const ElementControls = memo(forwardRef<HTMLDivElement, ElementControlsProps>(({
                 cancelAnimationFrame(animationFrameId);
             }
         };
-    }, [isDragging, dragStart, element, scale, updateElement, setDragStart, endDrag]);
+    }, [isDragging, dragStart, element, scale, updateElement, setDragStart, endDrag, isResizing]);
 
     // Handle resizing
     useEffect(() => {


### PR DESCRIPTION
## Summary
- ensure drag listeners cleanup when resizing starts

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843247487b08320bc0e41f8977b6674