### PR TITLE
Fix marquee selection overlay in editor

### DIFF
--- a/app/(routes)/editor/components/Editor.tsx
+++ b/app/(routes)/editor/components/Editor.tsx
@@ -13,6 +13,7 @@ import Canvas from "./canvas/Canvas";
 import ElementControls from "./canvas/controls/ElementControls";
 import { ElementActionBar } from "./canvas/ElementActionBar";
 import PageNavigation from "./PageNavigation";
+import MarqueeSelection from "./canvas/MarqueeSelection";
 
 
 /**
@@ -420,6 +421,8 @@ export default function Editor() {
                         }}
                     />
                 ))}
+
+                <MarqueeSelection canvasRef={canvasRef} />
 
             </div>
 

--- a/app/(routes)/editor/components/canvas/Canvas.tsx
+++ b/app/(routes)/editor/components/canvas/Canvas.tsx
@@ -2,7 +2,6 @@
 
 import { AlignmentGuides } from "@/(routes)/editor/components/canvas/AlignmentGuides"
 import { CanvasElement } from "@/(routes)/editor/components/canvas/CanvasElement"
-import MarqueeSelection from "./MarqueeSelection"
 import { calculateFitScale } from "@/lib/utils/canvas-utils"
 import useCanvasStore, { useCurrentCanvasSize, useCurrentPageElements } from "@lib/stores/useCanvasStore"
 import useEditorStore from "@lib/stores/useEditorStore"
@@ -293,7 +292,6 @@ const CanvasComponent: ForwardRefRenderFunction<HTMLDivElement, CanvasProps> = (
           />
         ))
       }
-      <MarqueeSelection canvasRef={canvasRef as React.RefObject<HTMLDivElement>} />
     </div>
   )
 }

--- a/app/(routes)/editor/components/canvas/MarqueeSelection.tsx
+++ b/app/(routes)/editor/components/canvas/MarqueeSelection.tsx
@@ -77,14 +77,24 @@ export default function MarqueeSelection({ canvasRef }: MarqueeSelectionProps) {
     };
   }, [isSelecting, start, elements, selectMultipleElements, selectedElementIds]);
 
-  const handleMouseDown = (e: React.MouseEvent) => {
-    if (!isEditMode) return;
-    if (!canvasRef.current || e.target !== canvasRef.current) return;
-    if (e.button !== 0) return;
-    setIsSelecting(true);
-    setStart({ x: e.clientX, y: e.clientY });
-    setEnd({ x: e.clientX, y: e.clientY });
-  };
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    const handleMouseDown = (e: MouseEvent) => {
+      if (!isEditMode) return;
+      if (e.target !== canvas) return;
+      if (e.button !== 0) return;
+      setIsSelecting(true);
+      setStart({ x: e.clientX, y: e.clientY });
+      setEnd({ x: e.clientX, y: e.clientY });
+    };
+
+    canvas.addEventListener('mousedown', handleMouseDown);
+    return () => {
+      canvas.removeEventListener('mousedown', handleMouseDown);
+    };
+  }, [canvasRef, isEditMode]);
 
   const style = start && end ? {
     left: Math.min(start.x, end.x),
@@ -94,7 +104,7 @@ export default function MarqueeSelection({ canvasRef }: MarqueeSelectionProps) {
   } : undefined;
 
   return (
-    <div className="absolute inset-0 pointer-events-none" onMouseDown={handleMouseDown}>
+    <div className="absolute inset-0 pointer-events-none">
       {isSelecting && start && end && (
         <div
           className="absolute border-2 border-brand-blue/50 bg-brand-blue/10"


### PR DESCRIPTION
## Summary
- fix MarqueeSelection to listen on the canvas element and render pointer-events-none overlay
- remove MarqueeSelection from Canvas component
- render MarqueeSelection at the editor level so it's not scaled with the canvas

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68443ea7ef288320a042e7d8b8ada111