### PR TITLE
Refactor repeated styling into reusable components

### DIFF
--- a/app/(routes)/(auth)/signin/page.tsx
+++ b/app/(routes)/(auth)/signin/page.tsx
@@ -5,8 +5,8 @@ import { Alert, AlertDescription } from "@components/ui/alert";
 import { Button } from "@components/ui/button";
 import { Checkbox } from "@components/ui/checkbox";
 import { Input } from "@components/ui/input";
+import { PasswordInput } from "@components/ui/password-input";
 import { Label } from "@components/ui/label";
-import { Eye, EyeOff } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
@@ -17,7 +17,6 @@ export default function SignIn() {
   const [password, setPassword] = useState("");
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState("");
-  const [showPassword, setShowPassword] = useState(false);
   const [rememberMe, setRememberMe] = useState(false);
 
   // Redirect authenticated users away from signin page
@@ -162,31 +161,16 @@ export default function SignIn() {
                   Forgot Password?
                 </Link>
               </div>
-              <div className="relative">
-                <Input
-                  id="password"
-                  type={showPassword ? "text" : "password"}
-                  placeholder="••••••••"
-                  value={password}
-                  onChange={(e) => setPassword(e.target.value)}
-                  required
-                  disabled={isLoading}
-                  className="w-full rounded-2xl"
-                  autoComplete="current-password"
-                />
-                <button
-                  type="button"
-                  onClick={() => setShowPassword(!showPassword)}
-                  className="absolute right-4 top-1/2 transform -translate-y-1/2 text-gray-500"
-                  tabIndex={-1}
-                >
-                  {showPassword ? (
-                    <EyeOff size={18} />
-                  ) : (
-                    <Eye size={18} />
-                  )}
-                </button>
-              </div>
+              <PasswordInput
+                id="password"
+                placeholder="••••••••"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                required
+                disabled={isLoading}
+                className="w-full rounded-2xl"
+                autoComplete="current-password"
+              />
             </div>
 
             <div className="flex items-center">
@@ -207,7 +191,8 @@ export default function SignIn() {
 
             <Button
               type="submit"
-              className="w-full rounded-2xl bg-gradient-to-r from-brand-blue to-brand-teal hover:from-brand-blue-dark hover:to-brand-teal-dark text-white font-medium py-3 h-auto"
+              variant="gradient"
+              className="w-full rounded-2xl py-3 h-auto"
               disabled={isLoading}
             >
               {isLoading ? (

--- a/app/(routes)/(auth)/signup/page.tsx
+++ b/app/(routes)/(auth)/signup/page.tsx
@@ -6,10 +6,10 @@ import Link from "next/link";
 import { signIn, useSession } from "next-auth/react";
 import { Button } from "@components/ui/button";
 import { Input } from "@components/ui/input";
+import { PasswordInput } from "@components/ui/password-input";
 import { Checkbox } from "@components/ui/checkbox";
 import { Label } from "@components/ui/label";
 import { Alert, AlertDescription } from "@components/ui/alert";
-import { Eye, EyeOff } from "lucide-react";
 import { z } from "zod";
 import { authAPI } from "@lib/api";
 
@@ -33,7 +33,6 @@ export default function SignUp() {
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
-  const [showPassword, setShowPassword] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [errors, setErrors] = useState<FormErrors>({});
   const [agreeToTerms, setAgreeToTerms] = useState(false);
@@ -190,31 +189,16 @@ export default function SignUp() {
 
             <div className="space-y-2">
               <Label htmlFor="password" className="text-gray-700">Password</Label>
-              <div className="relative">
-                <Input
-                  id="password"
-                  type={showPassword ? "text" : "password"}
-                  placeholder="••••••••"
-                  value={password}
-                  onChange={(e) => setPassword(e.target.value)}
-                  required
-                  disabled={isLoading}
-                  className="w-full rounded-2xl"
-                  autoComplete="new-password"
-                />
-                <button
-                  type="button"
-                  onClick={() => setShowPassword(!showPassword)}
-                  className="absolute right-4 top-1/2 transform -translate-y-1/2 text-gray-500"
-                  tabIndex={-1}
-                >
-                  {showPassword ? (
-                    <EyeOff size={18} />
-                  ) : (
-                    <Eye size={18} />
-                  )}
-                </button>
-              </div>
+              <PasswordInput
+                id="password"
+                placeholder="••••••••"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                required
+                disabled={isLoading}
+                className="w-full rounded-2xl"
+                autoComplete="new-password"
+              />
               {errors.password && (
                 <p className="text-sm text-red-500">{errors.password[0]}</p>
               )}
@@ -238,7 +222,8 @@ export default function SignUp() {
 
             <Button
               type="submit"
-              className="w-full rounded-2xl bg-gradient-to-r from-brand-blue to-brand-teal hover:from-brand-blue-dark hover:to-brand-teal-dark text-white font-medium py-3 h-auto"
+              variant="gradient"
+              className="w-full rounded-2xl py-3 h-auto"
               disabled={isLoading}
             >
               {isLoading ? (

--- a/app/(routes)/(site)/profile/page.tsx
+++ b/app/(routes)/(site)/profile/page.tsx
@@ -339,7 +339,8 @@ export default function ProfilePage() {
                       <Button
                         type="submit"
                         form="profile-form"
-                        className="rounded-xl bg-gradient-to-r from-brand-blue to-brand-teal hover:from-brand-blue-dark hover:to-brand-teal-dark text-white"
+                        variant="gradient"
+                        className="rounded-xl"
                         size="sm"
                       >
                         <Check className="h-4 w-4 mr-2" />

--- a/app/components/features/dashboard/index.tsx
+++ b/app/components/features/dashboard/index.tsx
@@ -306,7 +306,8 @@ function DashboardContent() {
             <p className="text-gray-500 mb-6 max-w-sm">There was an error loading your projects. Please try again.</p>
             <Button
               onClick={() => refetch()}
-              className="rounded-2xl bg-gradient-to-r from-brand-blue to-brand-teal hover:from-brand-blue-dark hover:to-brand-teal-dark text-white font-medium"
+              variant="gradient"
+              className="rounded-2xl"
             >
               Try Again
             </Button>

--- a/app/components/layout/sidebar.tsx
+++ b/app/components/layout/sidebar.tsx
@@ -4,6 +4,7 @@ import { Button } from "@components/ui/button"
 import { Input } from "@components/ui/input"
 import { cn } from "@/lib/utils/utils"
 import { AppWindow, Crown, Folder, LayoutGrid, Search, Settings, Shapes, Sparkles, Type, Upload } from "lucide-react"
+import { TextStyleCard } from "@components/ui/text-style-card"
 import { useEffect, useState } from "react"
 import useCanvasStore, { useCurrentCanvasSize } from "@lib/stores/useCanvasStore"
 
@@ -153,19 +154,15 @@ export default function Sidebar() {
             </div>
 
             <div className="space-y-3 mb-8">
-              <div
-                className="cursor-pointer rounded-lg border border-gray-200 bg-white p-4 transition-all duration-200 ease-in-out hover:border-brand-blue/30 hover:shadow-[0_2px_12px_rgba(30,136,229,0.1)]"
-                onClick={() => handleAddText(32, "Title", "bold")}
+              <TextStyleCard onClick={() => handleAddText(32, "Title", "bold")}
               >
                 <p className="text-2xl font-bold">Title</p>
-              </div>
+              </TextStyleCard>
 
-              <div
-                className="cursor-pointer rounded-lg border border-gray-200 bg-white p-4 transition-all duration-200 ease-in-out hover:border-brand-blue/30 hover:shadow-[0_2px_12px_rgba(30,136,229,0.1)]"
-                onClick={() => handleAddText(24, "Heading", "semibold")}
+              <TextStyleCard onClick={() => handleAddText(24, "Heading", "semibold")}
               >
                 <p className="text-xl font-semibold">Heading</p>
-              </div>
+              </TextStyleCard>
             </div>
 
             <div className="mt-6 mb-3">
@@ -173,31 +170,27 @@ export default function Sidebar() {
             </div>
 
             <div className="space-y-3 mb-8">
-              <div
-                className="cursor-pointer rounded-lg border border-gray-200 bg-white p-4 transition-all duration-200 ease-in-out hover:border-brand-blue/30 hover:shadow-[0_2px_12px_rgba(30,136,229,0.1)]"
-                onClick={() => handleAddText(18, "Add a subheading")}
+              <TextStyleCard onClick={() => handleAddText(18, "Add a subheading")}
               >
                 <p className="text-lg">Add a subheading</p>
-              </div>
+              </TextStyleCard>
 
-              <div
-                className="cursor-pointer rounded-lg border border-gray-200 bg-white p-4 transition-all duration-200 ease-in-out hover:border-brand-blue/30 hover:shadow-[0_2px_12px_rgba(30,136,229,0.1)]"
-                onClick={() => handleAddText(14, "Add a little bit of body text")}
+              <TextStyleCard onClick={() => handleAddText(14, "Add a little bit of body text")}
               >
                 <p className="text-sm">Add a little bit of body text</p>
-              </div>
+              </TextStyleCard>
             </div>
 
             <div className="mt-6 mb-3">
               <h3 className="text-sm font-semibold text-gray-800">Dynamic text</h3>
             </div>
 
-            <div className="cursor-pointer rounded-lg border border-gray-200 bg-white p-3 transition-all duration-200 ease-in-out hover:border-brand-blue/30 hover:shadow-[0_2px_12px_rgba(30,136,229,0.1)] flex items-center">
+            <TextStyleCard className="p-3 flex items-center">
               <div className="h-12 w-12 rounded bg-gradient-to-br from-brand-blue to-brand-teal flex items-center justify-center text-white font-bold mr-3">
                 1
               </div>
               <span className="text-sm font-medium">Page numbers</span>
-            </div>
+            </TextStyleCard>
           </div>
         </div>
       )}

--- a/app/components/ui/button.tsx
+++ b/app/components/ui/button.tsx
@@ -18,6 +18,8 @@ const buttonVariants = cva(
           "bg-secondary text-secondary-foreground hover:bg-secondary/80",
         ghost: "hover:bg-accent hover:text-accent-foreground",
         link: "text-primary underline-offset-4 hover:underline",
+        gradient:
+          "bg-gradient-to-r from-brand-blue to-brand-teal hover:from-brand-blue-dark hover:to-brand-teal-dark text-white",
       },
       size: {
         default: "h-10 px-4 py-2",

--- a/app/components/ui/password-input.tsx
+++ b/app/components/ui/password-input.tsx
@@ -1,0 +1,28 @@
+import { Input } from "./input";
+import { Eye, EyeOff } from "lucide-react";
+import { cn } from "@/lib/utils/utils";
+import { useState } from "react";
+import * as React from "react";
+
+export interface PasswordInputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+export function PasswordInput({ className, ...props }: PasswordInputProps) {
+  const [show, setShow] = useState(false);
+  return (
+    <div className="relative">
+      <Input
+        {...props}
+        type={show ? "text" : "password"}
+        className={cn("pr-10", className)}
+      />
+      <button
+        type="button"
+        onClick={() => setShow(!show)}
+        className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500"
+        tabIndex={-1}
+      >
+        {show ? <EyeOff size={18} /> : <Eye size={18} />}
+      </button>
+    </div>
+  );
+}

--- a/app/components/ui/text-style-card.tsx
+++ b/app/components/ui/text-style-card.tsx
@@ -1,0 +1,16 @@
+import { cn } from "@/lib/utils/utils";
+import * as React from "react";
+
+export interface TextStyleCardProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export function TextStyleCard({ className, ...props }: TextStyleCardProps) {
+  return (
+    <div
+      className={cn(
+        "cursor-pointer rounded-lg border border-gray-200 bg-white p-4 transition-all duration-200 ease-in-out hover:border-brand-blue/30 hover:shadow-[0_2px_12px_rgba(30,136,229,0.1)]",
+        className
+      )}
+      {...props}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- add gradient variant to `Button`
- create `PasswordInput` field with built-in visibility toggle
- create `TextStyleCard` for consistent sidebar text styles
- use new components in signin/signup/profile/pages and dashboard retry button
- clean up sidebar repeated markup

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846c81ce0188320b64906371707f5ad