### PR TITLE
Introduce reusable UI helpers

### DIFF
--- a/app/(routes)/(site)/assets/page.tsx
+++ b/app/(routes)/(site)/assets/page.tsx
@@ -9,6 +9,7 @@ import { Badge } from "@components/ui/badge"
 import { Button } from "@components/ui/button"
 import { Card, CardContent } from "@components/ui/card"
 import { Skeleton } from "@components/ui/skeleton"
+import EmptyState from "@/components/ui/empty-state"
 import { useToast } from "@components/ui/use-toast"
 import { useAssets } from "@features/assets/use-assets"
 import { Asset } from "@lib/types/api"
@@ -503,28 +504,27 @@ function AssetsPageContent() {
 
                 {/* Empty state */}
                 {filteredAssets.length === 0 && !isLoading && (
-                    <div className="flex flex-col items-center justify-center py-16 px-4 text-center">
-                        <Upload className="h-16 w-16 text-gray-400 mx-auto mb-4" />
-                        <h2 className="text-xl font-semibold mb-2">No assets found</h2>
-                        <p className="text-gray-600 mb-4">
-                            {searchQuery || filterType !== 'all'
-                                ? "Try adjusting your search or filters"
-                                : "Start by uploading your first asset"
-                            }
-                        </p>
+                    <EmptyState
+                        icon={<Upload className="h-16 w-16 text-gray-400 mx-auto" />}
+                        heading="No assets found"
+                        message={searchQuery || filterType !== 'all' ?
+                            "Try adjusting your search or filters" :
+                            "Start by uploading your first asset"}
+                    >
                         {(!searchQuery && filterType === 'all') && (
-                            <Button onClick={open}>
+                            <Button variant="gradient" onClick={open}>
                                 <Plus className="h-4 w-4 mr-2" />
                                 Upload Your First Asset
                             </Button>
                         )}
-                    </div>
+                    </EmptyState>
                 )}
 
                 {/* Upload button for empty state or floating action */}
                 {filteredAssets.length > 0 && (
                     <div className="fixed bottom-6 right-6">
                         <Button
+                            variant="gradient"
                             onClick={open}
                         >
                             <Plus className="h-5 w-5 mr-2" />

--- a/app/components/features/dashboard/index.tsx
+++ b/app/components/features/dashboard/index.tsx
@@ -296,7 +296,8 @@ function DashboardContent() {
             <p className="text-gray-500 mb-6 max-w-sm">There was an error loading your projects. Please try again.</p>
             <Button
               onClick={() => refetch()}
-              className="rounded-2xl bg-gradient-to-r from-brand-blue to-brand-teal hover:from-brand-blue-dark hover:to-brand-teal-dark text-white font-medium"
+              variant="gradient"
+              className="rounded-2xl"
             >
               Try Again
             </Button>
@@ -366,25 +367,22 @@ function DashboardContent() {
                 <Button
                   onClick={handleCreatePresentation}
                   disabled={isCreating}
-                  className="group relative rounded-2xl overflow-hidden bg-transparent font-medium py-3 h-auto transition-all duration-300"
+                  variant="gradient"
+                  className="rounded-2xl font-medium py-3 h-auto"
                 >
-                  <span className="absolute inset-0 bg-gradient-to-r from-brand-blue to-brand-teal transition-opacity duration-200 ease-in-out"></span>
-                  <span className="absolute inset-0 bg-gradient-to-r from-brand-blue-dark to-brand-teal-dark opacity-0 group-hover:opacity-100 transition-opacity duration-200 ease-in-out"></span>
-                  <span className="relative z-10 px-4 py-1 flex items-center text-white">
-                    {isCreating ? (
-                      <span className="flex items-center">
-                        <svg className="animate-spin -ml-1 mr-3 h-4 w-4 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                          <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
-                          <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-                        </svg>
-                        Creating...
-                      </span>
-                    ) : (
-                      <>
-                        <Plus className="mr-2 h-4 w-4 transition-transform duration-300 group-hover:scale-110" /> Create Project
-                      </>
-                    )}
-                  </span>
+                  {isCreating ? (
+                    <span className="flex items-center">
+                      <svg className="animate-spin -ml-1 mr-3 h-4 w-4 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                        <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+                        <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                      </svg>
+                      Creating...
+                    </span>
+                  ) : (
+                    <>
+                      <Plus className="mr-2 h-4 w-4" /> Create Project
+                    </>
+                  )}
                 </Button>
               </div>
             )}

--- a/app/components/layout/navbar.tsx
+++ b/app/components/layout/navbar.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { Avatar, AvatarFallback } from "@components/ui/avatar"
+import AvatarWithFallback from "@/components/ui/avatar-with-fallback"
 import { Button } from "@components/ui/button"
 import { ArrowLeft, ArrowRight, ChevronDown, Save, Share2, Edit, Eye } from "lucide-react"
 import useEditorStore from "@lib/stores/useEditorStore"
@@ -260,9 +260,10 @@ export default function EditorNavbar() {
         
         <div className="h-7 w-px bg-white/20 mx-0.5"></div>
         
-        <Avatar className="h-8 w-8 border border-white/20 bg-brand-blue-dark text-white shadow-sm hover:shadow transition-shadow cursor-pointer">
-          <AvatarFallback className="text-sm font-medium">MP</AvatarFallback>
-        </Avatar>
+        <AvatarWithFallback
+          name="MP"
+          className="h-8 w-8 border border-white/20 bg-brand-blue-dark text-white shadow-sm hover:shadow transition-shadow cursor-pointer"
+        />
       </div>
     </div>
   )

--- a/app/components/ui/avatar-with-fallback.tsx
+++ b/app/components/ui/avatar-with-fallback.tsx
@@ -1,0 +1,23 @@
+"use client"
+
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
+import { cn } from "@/lib/utils/utils"
+
+interface AvatarWithFallbackProps {
+  name: string
+  src?: string
+  className?: string
+}
+
+export function AvatarWithFallback({ name, src, className }: AvatarWithFallbackProps) {
+  return (
+    <Avatar className={className}>
+      {src && <AvatarImage src={src} alt={name} />}
+      <AvatarFallback className="bg-gradient-to-br from-brand-blue-light to-brand-teal-light text-white">
+        {name.slice(0, 2).toUpperCase()}
+      </AvatarFallback>
+    </Avatar>
+  )
+}
+
+export default AvatarWithFallback

--- a/app/components/ui/button.tsx
+++ b/app/components/ui/button.tsx
@@ -18,6 +18,8 @@ const buttonVariants = cva(
           "bg-secondary text-secondary-foreground hover:bg-secondary/80",
         ghost: "hover:bg-accent hover:text-accent-foreground",
         link: "text-primary underline-offset-4 hover:underline",
+        gradient:
+          "brand-gradient text-white hover:brand-gradient-dark",
       },
       size: {
         default: "h-10 px-4 py-2",

--- a/app/components/ui/empty-state.tsx
+++ b/app/components/ui/empty-state.tsx
@@ -1,0 +1,25 @@
+"use client"
+
+import { ReactNode } from "react"
+import { cn } from "@/lib/utils/utils"
+
+interface EmptyStateProps {
+  icon?: ReactNode
+  heading: string
+  message?: ReactNode
+  className?: string
+  children?: ReactNode
+}
+
+export function EmptyState({ icon, heading, message, className, children }: EmptyStateProps) {
+  return (
+    <div className={cn("flex flex-col items-center justify-center py-16 px-4 text-center", className)}>
+      {icon && <div className="mb-4">{icon}</div>}
+      <h3 className="text-xl font-medium mb-2">{heading}</h3>
+      {message && <p className="text-gray-500 mb-4 max-w-sm">{message}</p>}
+      {children}
+    </div>
+  )
+}
+
+export default EmptyState

--- a/app/styles/globals.css
+++ b/app/styles/globals.css
@@ -25,6 +25,12 @@ body {
   .text-balance {
     text-wrap: balance;
   }
+  .brand-gradient {
+    @apply bg-gradient-to-r from-brand-blue to-brand-teal;
+  }
+  .brand-gradient-dark {
+    @apply bg-gradient-to-r from-brand-blue-dark to-brand-teal-dark;
+  }
 }
 
 @layer base {


### PR DESCRIPTION
## Summary
- create `EmptyState` and `AvatarWithFallback` components
- add `brand-gradient` utilities and gradient button variant
- apply new components and variant in the assets page, navbar and dashboard

## Testing
- `npx next lint` *(fails: 403 Forbidden)*
- `npm test` *(fails: Missing script)*


------
https://chatgpt.com/codex/tasks/task_e_68473dddb8308320993a5246e1101143